### PR TITLE
Add option to fill expansion

### DIFF
--- a/plugin/foldtext.vim
+++ b/plugin/foldtext.vim
@@ -9,6 +9,7 @@ let g:FoldText_line           = get(g:, 'FoldText_line',           defaults['lin
 let g:FoldText_multiplication = get(g:, 'FoldText_multiplication', defaults['multiplication'])
 let g:FoldText_info           = get(g:, 'FoldText_info',           1)
 let g:FoldText_width          = get(g:, 'FoldText_width',          0)
+let g:FoldText_expansion      = get(g:, 'FoldText_expansion',      "<=>")
 
 unlet defaults
 
@@ -70,7 +71,14 @@ function! FoldText()
         endif
     endif
 
-    let expansionStr = repeat(" ", width - strwidth(line . foldEnding . ending))
+    let expansionWidth = width - strwidth(line . foldEnding . ending)
+    let expansionStr = repeat(" ", expansionWidth)
+    if expansionWidth > 2
+      let extensionCenterWidth = strwidth(g:FoldText_expansion[1:-2])
+      let remainder = (expansionWidth - 2) % extensionCenterWidth
+      echo remainder extensionCenterWidth expansionWidth
+      let expansionStr = g:FoldText_expansion[0] . repeat(g:FoldText_expansion[1:-2], (expansionWidth - 2)/extensionCenterWidth) . repeat(g:FoldText_expansion[-2:-2], remainder) . g:FoldText_expansion[-1:]
+    endif
     return line . foldEnding . expansionStr . ending
 endfunction
 


### PR DESCRIPTION
Add an an option `g:FoldText_expansion` that defines the fill of the expansion string.

The value should be 3 or more characters:
- The starting character
- And arbitrary number of in-between characters
- The end character

How it works:
If the expansion is greater 2 (start+end string) fill expansion as follows:
- Prepend with start character, append end character
- repeat in-between character to fill up
- if in-between space is not an exact multiple of the number of in-between character, fill remainder with last of in-between characters
  (To keep line column straight, something needs to be filled. Last character is most likely to fit the end character)

This allows not only the expansion to be uniformly filled but use neat ligatures of fonts.
For example I use following setting with FiraCode:
```
let g:FoldText_expansion="<=//=>"
```

![image](https://github.com/jrudess/vim-foldtext/assets/7070761/c1cddf94-3f84-47b5-be7d-57edfa61afaf)